### PR TITLE
Bump python from 3.7.2-alpine to 3.7.4-alpine in /scripts

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.2-alpine
+FROM python:3.7.4-alpine
 
 WORKDIR /usr/src/scripts
 


### PR DESCRIPTION
Bumps python from 3.7.2-alpine to 3.7.4-alpine.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>